### PR TITLE
Extract user-visible dependency loading and initialization from WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,32 +3,10 @@ workspace(
     managed_directories = {"@npm": ["node_modules"]},
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "build_bazel_rules_nodejs",
-    sha256 = "e1a0d6eb40ec89f61a13a028e7113aa3630247253bcb1406281b627e44395145",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.0.1/rules_nodejs-1.0.1.tar.gz"],
-)
-
-http_archive(
-    name = "io_bazel_rules_sass",
-    sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
-    urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
-    ],
-    strip_prefix = "rules_sass-1.23.7",
-)
-
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
+load("//:package.bzl", "rules_postcss_dependencies")
+rules_postcss_dependencies()
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
-
 yarn_install(
     name = "npm",
     package_json = "//:package.json",
@@ -36,9 +14,7 @@ yarn_install(
 )
 
 load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
-
 install_bazel_dependencies()
 
-# Set up TypeScript toolchain
-load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
-ts_setup_workspace()
+load("//:repositories.bzl", "postcss_repositories")
+postcss_repositories()

--- a/package.bzl
+++ b/package.bzl
@@ -1,0 +1,42 @@
+# Copyright 2020 The Bazel Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fetches transitive dependencies required for using the PostCSS rules"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _include_if_not_defined(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)
+
+def rules_postcss_dependencies():
+    # NodeJS rules.
+    _include_if_not_defined(
+        http_archive,
+        name = "build_bazel_rules_nodejs",
+        sha256 = "e1a0d6eb40ec89f61a13a028e7113aa3630247253bcb1406281b627e44395145",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.0.1/rules_nodejs-1.0.1.tar.gz"],
+    )
+
+    # Sass rules.
+    _include_if_not_defined(
+        http_archive,
+        name = "io_bazel_rules_sass",
+        sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
+        urls = [
+            "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+        ],
+        strip_prefix = "rules_sass-1.23.7",
+    )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,31 @@
+# Copyright 2020 The Bazel Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Install PostCSS toolchain dependencies"""
+
+load("@build_bazel_rules_nodejs//:index.bzl", "check_rules_nodejs_version")
+load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
+load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
+
+def postcss_repositories():
+    """Set up environment for PostCSS."""
+
+    check_rules_nodejs_version("1.0.1")
+
+    rules_sass_dependencies()
+
+    sass_repositories()
+
+    ts_setup_workspace()


### PR DESCRIPTION
This allows downstream dependents to set up the PostCSS build rules without duplicating much of what is in the WORKSPACE in this repo.

Structure loosely follows rules_sass:
- https://github.com/bazelbuild/rules_sass/blob/ff9c3677d6a330943812a8acd76b79aabc7c82cd/package.bzl
- https://github.com/bazelbuild/rules_sass/blob/f2839867b43d14027f346ee177be2a4083a7c6c0/sass/sass_repositories.bzl