### PR TITLE
Use absolute path to refer to PostCSS runner template

### DIFF
--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -89,7 +89,7 @@ def postcss_gen_runner(
         name = runner_src_name,
         plugins = plugins,
         map_annotation = map_annotation,
-        template = "//internal:runner-template.js",
+        template = "@build_bazel_rules_postcss//internal:runner-template.js",
         visibility = ["//visibility:private"],
     )
 


### PR DESCRIPTION
Because postcss_gen_runner is a macro, downstream users would otherwise be making a reference to their own `//internal:runner-template.js`, which would not work.