### PR TITLE
Macros should accept standard Bazel attributes

### DIFF
--- a/internal/autoprefixer/build_defs.bzl
+++ b/internal/autoprefixer/build_defs.bzl
@@ -21,7 +21,8 @@ def autoprefixer(
         src,
         out,
         browsers = "> 1%",
-        visibility = None):
+        visibility = None,
+        compatible_with = None):
     """Runs autoprefixer on the given source files located in the given fileset.
 
     Args:
@@ -33,6 +34,7 @@ def autoprefixer(
                   See https://github.com/ai/browserslist for more queries. If empty
                   or blank, include all known prefixes. Default is '> 1%'.
         visibility: The visibility of the build rule.
+        compatible_with: Standard BUILD compatible_with.
     """
 
     postcss_binary(
@@ -46,4 +48,5 @@ def autoprefixer(
         src = src,
         output_name = out,
         visibility = visibility,
+        compatible_with = compatible_with,
     )

--- a/internal/autoprefixer/build_defs.bzl
+++ b/internal/autoprefixer/build_defs.bzl
@@ -21,8 +21,7 @@ def autoprefixer(
         src,
         out,
         browsers = "> 1%",
-        visibility = None,
-        compatible_with = None):
+        **kwargs):
     """Runs autoprefixer on the given source files located in the given fileset.
 
     Args:
@@ -33,8 +32,7 @@ def autoprefixer(
                   or "> 5%, > 2% in US, Firefox > 20").
                   See https://github.com/ai/browserslist for more queries. If empty
                   or blank, include all known prefixes. Default is '> 1%'.
-        visibility: The visibility of the build rule.
-        compatible_with: Standard BUILD compatible_with.
+        **kwargs: Additional arguments to pass to postcss_binary().
     """
 
     postcss_binary(
@@ -47,6 +45,5 @@ def autoprefixer(
         ],
         src = src,
         output_name = out,
-        visibility = visibility,
-        compatible_with = compatible_with,
+        **kwargs
     )

--- a/internal/binary.bzl
+++ b/internal/binary.bzl
@@ -58,10 +58,9 @@ def postcss_binary(
         plugins_keyed_by_infos["%s.info" % key] = value
 
     kwargs_always_private = dict()
-    for (key, value) in kwargs:
-        if key == "visibility":
-            value = "//visibility:private"
+    for (key, value) in kwargs.items():
         kwargs_always_private[key] = value
+    kwargs_always_private.setdefault("visibility", ["//visibility:private"])
 
     postcss_gen_runner(
         name = runner_name,

--- a/internal/binary.bzl
+++ b/internal/binary.bzl
@@ -19,6 +19,7 @@ it using a provided list of PostCSS plugins, against input .css (and optionally
 .css.map).
 """
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":gen_runner.bzl", "postcss_gen_runner")
 load(":run.bzl", "postcss_run")
 
@@ -62,8 +63,7 @@ def postcss_binary(
         plugins = plugins_keyed_by_infos,
         deps = deps,
         map_annotation = map_annotation,
-        visibility = ["//visibility:private"],
-        **{k: kwargs.get(k) for k in kwargs if k not in ["visibility"]}
+        **dicts.add(kwargs, {"visibility": ["//visibility:private"]})
     )
 
     postcss_run(

--- a/internal/binary.bzl
+++ b/internal/binary.bzl
@@ -30,8 +30,7 @@ def postcss_binary(
         additional_outputs = [],
         output_name = "",
         map_annotation = False,
-        visibility = None,
-        compatible_with = None):
+        **kwargs):
     """Runs PostCSS.
 
     Args:
@@ -49,8 +48,7 @@ def postcss_binary(
         map_annotation: Whether to add (or modify, if already existing) the
             sourceMappingURL comment in the output .css to point to the output
             .css.map.
-        visibility: The visibility of the build rule.
-        compatible_with: Standard BUILD compatible_with.
+        **kwargs: Standard BUILD arguments to pass.
     """
 
     runner_name = "%s.postcss_runner" % name
@@ -59,13 +57,18 @@ def postcss_binary(
     for key, value in plugins.items():
         plugins_keyed_by_infos["%s.info" % key] = value
 
+    kwargs_always_private = dict()
+    for (key, value) in kwargs:
+        if key == "visibility":
+            value = "//visibility:private"
+        kwargs_always_private[key] = value
+
     postcss_gen_runner(
         name = runner_name,
         plugins = plugins_keyed_by_infos,
         deps = deps,
         map_annotation = map_annotation,
-        visibility = ["//visibility:private"],
-        compatible_with = compatible_with,
+        **kwargs_always_private
     )
 
     postcss_run(
@@ -74,6 +77,5 @@ def postcss_binary(
         output_name = output_name,
         additional_outputs = additional_outputs,
         runner = runner_name,
-        visibility = visibility,
-        compatible_with = compatible_with,
+        **kwargs
     )

--- a/internal/binary.bzl
+++ b/internal/binary.bzl
@@ -30,7 +30,8 @@ def postcss_binary(
         additional_outputs = [],
         output_name = "",
         map_annotation = False,
-        visibility = None):
+        visibility = None,
+        compatible_with = None):
     """Runs PostCSS.
 
     Args:
@@ -49,6 +50,7 @@ def postcss_binary(
             sourceMappingURL comment in the output .css to point to the output
             .css.map.
         visibility: The visibility of the build rule.
+        compatible_with: Standard BUILD compatible_with.
     """
 
     runner_name = "%s.postcss_runner" % name
@@ -63,6 +65,7 @@ def postcss_binary(
         deps = deps,
         map_annotation = map_annotation,
         visibility = ["//visibility:private"],
+        compatible_with = compatible_with,
     )
 
     postcss_run(
@@ -72,4 +75,5 @@ def postcss_binary(
         additional_outputs = additional_outputs,
         runner = runner_name,
         visibility = visibility,
+        compatible_with = compatible_with,
     )

--- a/internal/binary.bzl
+++ b/internal/binary.bzl
@@ -57,17 +57,13 @@ def postcss_binary(
     for key, value in plugins.items():
         plugins_keyed_by_infos["%s.info" % key] = value
 
-    kwargs_always_private = dict()
-    for (key, value) in kwargs.items():
-        kwargs_always_private[key] = value
-    kwargs_always_private.setdefault("visibility", ["//visibility:private"])
-
     postcss_gen_runner(
         name = runner_name,
         plugins = plugins_keyed_by_infos,
         deps = deps,
         map_annotation = map_annotation,
-        **kwargs_always_private
+        visibility = ["//visibility:private"],
+        **{k: kwargs.get(k) for k in kwargs if k not in ["visibility"]}
     )
 
     postcss_run(

--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -88,10 +88,9 @@ def postcss_gen_runner(
     runner_src_name = "%s.runner_src" % name
 
     kwargs_always_private = dict()
-    for (key, value) in kwargs:
-        if key == "visibility":
-            value = "//visibility:private"
+    for (key, value) in kwargs.items():
         kwargs_always_private[key] = value
+    kwargs_always_private.setdefault("visibility", ["//visibility:private"])
 
     postcss_runner_src(
         name = runner_src_name,

--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -67,8 +67,7 @@ def postcss_gen_runner(
         plugins,
         deps,
         map_annotation,
-        visibility = None,
-        compatible_with = None):
+        **kwargs):
     """Generates a PostCSS runner binary.
 
     Pass the result to a postcss_run rule to apply the runner to a css file.
@@ -83,19 +82,23 @@ def postcss_gen_runner(
         map_annotation: Whether to add (or modify, if already existing) the
             sourceMappingURL comment in the output .css to point to the output
             .css.map.
-        visibility: The visibility of the build rule.
-        compatible_with: Standard BUILD compatible_with.
+        **kwargs: Standard BUILD arguments to pass.
     """
 
     runner_src_name = "%s.runner_src" % name
+
+    kwargs_always_private = dict()
+    for (key, value) in kwargs:
+        if key == "visibility":
+            value = "//visibility:private"
+        kwargs_always_private[key] = value
 
     postcss_runner_src(
         name = runner_src_name,
         plugins = plugins,
         map_annotation = map_annotation,
         template = "@build_bazel_rules_postcss//internal:runner-template.js",
-        visibility = ["//visibility:private"],
-        compatible_with = compatible_with,
+        **kwargs_always_private
     )
 
     postcss_runner_bin(
@@ -105,6 +108,5 @@ def postcss_gen_runner(
             "@npm//minimist",
             "@npm//postcss",
         ] + deps,
-        visibility = visibility,
-        compatible_with = compatible_with,
+        **kwargs
     )

--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -87,17 +87,13 @@ def postcss_gen_runner(
 
     runner_src_name = "%s.runner_src" % name
 
-    kwargs_always_private = dict()
-    for (key, value) in kwargs.items():
-        kwargs_always_private[key] = value
-    kwargs_always_private.setdefault("visibility", ["//visibility:private"])
-
     postcss_runner_src(
         name = runner_src_name,
         plugins = plugins,
         map_annotation = map_annotation,
         template = "@build_bazel_rules_postcss//internal:runner-template.js",
-        **kwargs_always_private
+        visibility = ["//visibility:private"],
+        **{k: kwargs.get(k) for k in kwargs if k not in ["visibility"]}
     )
 
     postcss_runner_bin(

--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -17,6 +17,7 @@
 This generates the internal PostCSS runner as a nodejs_binary, that can later
 be used as an executable."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":runner_bin.bzl", "postcss_runner_bin")
 load(":plugin.bzl", "PostcssPluginInfo")
 
@@ -92,8 +93,7 @@ def postcss_gen_runner(
         plugins = plugins,
         map_annotation = map_annotation,
         template = "@build_bazel_rules_postcss//internal:runner-template.js",
-        visibility = ["//visibility:private"],
-        **{k: kwargs.get(k) for k in kwargs if k not in ["visibility"]}
+        **dicts.add(kwargs, {"visibility": ["//visibility:private"]})
     )
 
     postcss_runner_bin(

--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -67,7 +67,8 @@ def postcss_gen_runner(
         plugins,
         deps,
         map_annotation,
-        visibility = None):
+        visibility = None,
+        compatible_with = None):
     """Generates a PostCSS runner binary.
 
     Pass the result to a postcss_run rule to apply the runner to a css file.
@@ -83,6 +84,7 @@ def postcss_gen_runner(
             sourceMappingURL comment in the output .css to point to the output
             .css.map.
         visibility: The visibility of the build rule.
+        compatible_with: Standard BUILD compatible_with.
     """
 
     runner_src_name = "%s.runner_src" % name
@@ -93,6 +95,7 @@ def postcss_gen_runner(
         map_annotation = map_annotation,
         template = "@build_bazel_rules_postcss//internal:runner-template.js",
         visibility = ["//visibility:private"],
+        compatible_with = compatible_with,
     )
 
     postcss_runner_bin(
@@ -103,4 +106,5 @@ def postcss_gen_runner(
             "@npm//postcss",
         ] + deps,
         visibility = visibility,
+        compatible_with = compatible_with,
     )

--- a/internal/plugin.bzl
+++ b/internal/plugin.bzl
@@ -46,7 +46,8 @@ def postcss_plugin(
         srcs = [],
         data = [],
         deps = [],
-        visibility = None):
+        visibility = None,
+        compatible_with = None):
     """Represents a Node.js module that is a PostCSS plugin.
 
     This provides extra metadata about PostCSS plugins that will be consumed by
@@ -62,12 +63,14 @@ def postcss_plugin(
         data: Non-JS data files needed for the Node.js module.
         deps: Node.js module dependencies.
         visibility: The visibility of the build rule.
+        compatible_with: Standard BUILD compatible_with.
     """
 
     native.filegroup(
         name = name,
         srcs = srcs + data + deps,
         visibility = visibility,
+        compatible_with = compatible_with,
     )
 
     postcss_plugin_info(

--- a/internal/plugin.bzl
+++ b/internal/plugin.bzl
@@ -46,8 +46,7 @@ def postcss_plugin(
         srcs = [],
         data = [],
         deps = [],
-        visibility = None,
-        compatible_with = None):
+        **kwargs):
     """Represents a Node.js module that is a PostCSS plugin.
 
     This provides extra metadata about PostCSS plugins that will be consumed by
@@ -62,19 +61,17 @@ def postcss_plugin(
         srcs: JS sources for the Node.js module, if any.
         data: Non-JS data files needed for the Node.js module.
         deps: Node.js module dependencies.
-        visibility: The visibility of the build rule.
-        compatible_with: Standard BUILD compatible_with.
+        **kwargs: Standard BUILD arguments to pass.
     """
 
     native.filegroup(
         name = name,
         srcs = srcs + data + deps,
-        visibility = visibility,
-        compatible_with = compatible_with,
+        **kwargs
     )
 
     postcss_plugin_info(
         name = "%s.info" % name,
         node_require = node_require,
-        visibility = visibility,
+        **kwargs
     )

--- a/internal/rtlcss/build_defs.bzl
+++ b/internal/rtlcss/build_defs.bzl
@@ -20,16 +20,14 @@ def rtlcss(
         name,
         src,
         out,
-        visibility = None,
-        compatible_with = None):
+        **kwargs):
     """Runs rtlcss on the given source files located in the given fileset.
 
     Args:
         name: A unique label for this rule.
         src: Source file or target.
         out: Output file.
-        visibility: The visibility of the build rule.
-        compatible_with: Standard BUILD compatible_with.
+        **kwargs: Additional arguments to pass to postcss_binary().
     """
 
     postcss_binary(
@@ -42,6 +40,5 @@ def rtlcss(
         ],
         src = src,
         output_name = out,
-        visibility = visibility,
-        compatible_with = compatible_with,
+        **kwargs
     )

--- a/internal/rtlcss/build_defs.bzl
+++ b/internal/rtlcss/build_defs.bzl
@@ -20,7 +20,8 @@ def rtlcss(
         name,
         src,
         out,
-        visibility = None):
+        visibility = None,
+        compatible_with = None):
     """Runs rtlcss on the given source files located in the given fileset.
 
     Args:
@@ -28,6 +29,7 @@ def rtlcss(
         src: Source file or target.
         out: Output file.
         visibility: The visibility of the build rule.
+        compatible_with: Standard BUILD compatible_with.
     """
 
     postcss_binary(
@@ -41,4 +43,5 @@ def rtlcss(
         src = src,
         output_name = out,
         visibility = visibility,
+        compatible_with = compatible_with,
     )

--- a/internal/runner_bin.bzl
+++ b/internal/runner_bin.bzl
@@ -24,7 +24,8 @@ def postcss_runner_bin(
         name,
         src,
         deps,
-        visibility = None):
+        visibility = None,
+        compatible_with = None):
     """Convenience helper for using nodejs_binary with the PostCSS runner.
 
     Args:
@@ -32,6 +33,7 @@ def postcss_runner_bin(
         src: The source file and entry point of the nodejs_binary.
         deps: What the nodejs_binary depends on.
         visibility: The visibility of the build rule.
+        compatible_with: Standard BUILD compatible_with.
     """
 
     nodejs_binary(
@@ -39,4 +41,5 @@ def postcss_runner_bin(
         entry_point = ":%s" % (src),
         data = deps,
         visibility = visibility,
+        compatible_with = compatible_with,
     )

--- a/internal/runner_bin.bzl
+++ b/internal/runner_bin.bzl
@@ -24,22 +24,19 @@ def postcss_runner_bin(
         name,
         src,
         deps,
-        visibility = None,
-        compatible_with = None):
+        **kwargs):
     """Convenience helper for using nodejs_binary with the PostCSS runner.
 
     Args:
         name: The name of the build rule.
         src: The source file and entry point of the nodejs_binary.
         deps: What the nodejs_binary depends on.
-        visibility: The visibility of the build rule.
-        compatible_with: Standard BUILD compatible_with.
+        **kwargs: Additional arguments to pass to nodejs_binary().
     """
 
     nodejs_binary(
         name = name,
         entry_point = ":%s" % (src),
         data = deps,
-        visibility = visibility,
-        compatible_with = compatible_with,
+        **kwargs
     )


### PR DESCRIPTION
Which allows us to forward `visibility`, `compatible_with`, and any other standard Bazel rule attributes that get added in the future.

Done following https://docs.bazel.build/versions/2.0.0/skylark/tutorial-creating-a-macro.html

Fixes #16