### PR TITLE
Add a postcss_multi_binary rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Rules
 
 *   postcss_binary
+*   postcss_multi_binary
 *   postcss_plugin
 *   autoprefixer
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -19,10 +19,12 @@ Users should not load files under "/internal"
 
 load("//internal:plugin.bzl", _postcss_plugin = "postcss_plugin")
 load("//internal:binary.bzl", _postcss_binary = "postcss_binary")
+load("//internal:multi_binary.bzl", _postcss_multi_binary = "postcss_multi_binary")
 load("//internal/autoprefixer:build_defs.bzl", _autoprefixer = "autoprefixer")
 load("//internal/rtlcss:build_defs.bzl", _rtlcss = "rtlcss")
 
 postcss_plugin = _postcss_plugin
 postcss_binary = _postcss_binary
+postcss_multi_binary = _postcss_multi_binary
 autoprefixer = _autoprefixer
 rtlcss = _rtlcss

--- a/examples/multi_binary/BUILD
+++ b/examples/multi_binary/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2020 The Bazel Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//:defs.bzl", "postcss_plugin", "postcss_multi_binary")
+
+package(default_visibility = ["//tests:__subpackages__"])
+
+AUTO_PREFIXER_BROWSERS = "ie >= 9, edge >= 12, firefox >= 42, chrome >= 32, safari >= 8, opera >= 38, ios_saf >= 9.2, android >= 4.3, and_uc >= 9.9"
+
+postcss_plugin(
+    name = "autoprefixer",
+    node_require = "autoprefixer",
+)
+
+postcss_multi_binary(
+    name = "styles",
+    srcs = ["style1.css", "style2.css"],
+    output_pattern = "{rule}/{dir}/{name}",
+    plugins = {
+        ":autoprefixer": "[{ browsers: '%s' }]" % AUTO_PREFIXER_BROWSERS,
+    },
+    deps = ["@npm//autoprefixer"],
+)

--- a/examples/multi_binary/style1.css
+++ b/examples/multi_binary/style1.css
@@ -1,0 +1,4 @@
+body {
+  font: 42px 'Comic Sans MS';
+  flex: 42 -42 auto;
+}

--- a/examples/multi_binary/style2.css
+++ b/examples/multi_binary/style2.css
@@ -1,0 +1,4 @@
+body {
+  font: 42px 'Comic Sans MS';
+  flex: 42 -42 auto;
+}

--- a/internal/multi_binary.bzl
+++ b/internal/multi_binary.bzl
@@ -1,4 +1,4 @@
-# Copyright 2019 The Bazel Authors
+# Copyright 2020 The Bazel Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,9 +32,9 @@ def postcss_multi_binary(
         **kwargs):
     """Compiles multiple CSS files with the same PostCSS configuration.
 
-    This should generally be avoided if postcss_run would suffice. It's intended
-    to be used when the set of files to compile aren't known during the loading
-    phase.
+    This should generally be avoided if postcss_binary would suffice. It's
+    intended to be used when the set of files to compile aren't known during the
+    loading phase.
 
     Args:
         name: The name of the build rule.
@@ -60,6 +60,7 @@ def postcss_multi_binary(
             sourceMappingURL comment in the output .css to point to the output
             .css.map.
         **kwargs: Standard BUILD arguments to pass.
+
     """
 
     runner_name = "%s.postcss_runner" % name

--- a/internal/multi_binary.bzl
+++ b/internal/multi_binary.bzl
@@ -1,0 +1,85 @@
+# Copyright 2019 The Bazel Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A rule that compiles multiple CSS files with the same PostCSS configuration.
+
+This works like `postcss_binary` except that it takes multiple CSS sources and
+declares a separate action for each of them.
+"""
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load(":gen_runner.bzl", "postcss_gen_runner")
+load(":run.bzl", "postcss_multi_run")
+
+def postcss_multi_binary(
+        name,
+        plugins,
+        deps,
+        srcs,
+        output_pattern,
+        map_annotation = False,
+        **kwargs):
+    """Compiles multiple CSS files with the same PostCSS configuration.
+
+    This should generally be avoided if postcss_run would suffice. It's intended
+    to be used when the set of files to compile aren't known during the loading
+    phase.
+
+    Args:
+        name: The name of the build rule.
+        plugins: A map of plugin Node.js require paths (following the
+            requirements of rules_nodejs), with values being config objects
+            for each respective plugin.
+        deps: A list of NodeJS modules the config depends on. The PostCSS module
+            is always implicitly included.
+        srcs: The input .css (and optionally .css.map) files. If a .css.map file
+            is passed, its corresponding .css file must also exist.
+        output_pattern: A named pattern for the output file generated for each
+            input CSS file.
+
+            This pattern can include any or all of the following variables:
+
+            * "{name}", the input CSS file's basename.
+            * "{dir}", the input CSS file's directory name relative to the root
+              of the workspace.
+            * "{rule}", the name of this rule.
+
+            It defaults to "{rule}/{name}".
+        map_annotation: Whether to add (or modify, if already existing) the
+            sourceMappingURL comment in the output .css to point to the output
+            .css.map.
+        **kwargs: Standard BUILD arguments to pass.
+    """
+
+    runner_name = "%s.postcss_runner" % name
+
+    plugins_keyed_by_infos = {}
+    for key, value in plugins.items():
+        plugins_keyed_by_infos["%s.info" % key] = value
+
+    postcss_gen_runner(
+        name = runner_name,
+        plugins = plugins_keyed_by_infos,
+        deps = deps,
+        map_annotation = map_annotation,
+        **dicts.add(kwargs, {"visibility": ["//visibility:private"]})
+    )
+
+    postcss_multi_run(
+        name = name,
+        srcs = srcs,
+        output_pattern = output_pattern,
+        runner = runner_name,
+        **kwargs
+    )

--- a/internal/run.bzl
+++ b/internal/run.bzl
@@ -20,6 +20,32 @@ ERROR_INPUT_NO_CSS = "Input of one file must be of a .css file"
 ERROR_INPUT_TWO_FILES = "Input of two files must be of a .css and .css.map file"
 ERROR_INPUT_TOO_MANY = "Input must be up to two files, a .css file, and optionally a .css.map file"
 
+def _run_one(ctx, input_css, input_map, output_css, output_map):
+    """Compile a single CSS file to a single output file."""
+
+    # Generate the command line.
+    args = [
+        "--binDir=%s" % ctx.bin_dir.path,
+        "--cssFile=%s" % input_css.path,
+        "--outCssFile=%s" % output_css.path,
+        "--outCssMapFile=%s" % output_map.path,
+    ]
+    if input_map:
+        args.append("--cssMapFile=%s" % input_map.path)
+
+    # The command may only access files declared in inputs.
+    inputs = [input_css] + ([input_map] if input_map else [])
+
+    ctx.actions.run(
+        outputs = [output_css, output_map] + (
+            ctx.outputs.additional_outputs if hasattr(ctx.outputs, "additional_outputs") else []
+        ),
+        inputs = inputs,
+        executable = ctx.executable.runner,
+        arguments = args,
+        progress_message = "Running PostCSS runner on %s" % input_css,
+    )
+
 def _postcss_run_impl(ctx):
     # Get the list of files. Fail here if there are more than two files.
     file_list = ctx.files.src
@@ -28,42 +54,23 @@ def _postcss_run_impl(ctx):
 
     # Get the .css and .css.map files from the list, which we expect to always
     # contain a .css file, and optionally a .css.map file.
-    css_file = None
-    css_map_file = None
+    input_css = None
+    input_map = None
     for input_file in file_list:
         if input_file.extension == "css":
-            if css_file != None:
+            if input_css != None:
                 fail(ERROR_INPUT_TWO_FILES)
-            css_file = input_file
+            input_css = input_file
             continue
         if input_file.extension == "map":
-            if css_map_file != None:
+            if input_map != None:
                 fail(ERROR_INPUT_TWO_FILES)
-            css_map_file = input_file
+            input_map = input_file
             continue
-    if css_file == None:
+    if input_css == None:
         fail(ERROR_INPUT_NO_CSS)
 
-    # Generate the command line.
-    args = [
-        "--binDir=%s" % ctx.bin_dir.path,
-        "--cssFile=%s" % css_file.path,
-        "--outCssFile=%s" % ctx.outputs.css_file.path,
-        "--outCssMapFile=%s" % ctx.outputs.css_map_file.path,
-    ]
-    if css_map_file:
-        args.append("--cssMapFile=%s" % css_map_file.path)
-
-    # The command may only access files declared in inputs.
-    inputs = [css_file] + ([css_map_file] if css_map_file else [])
-
-    ctx.actions.run(
-        outputs = [ctx.outputs.css_file, ctx.outputs.css_map_file] + ctx.outputs.additional_outputs,
-        inputs = inputs,
-        executable = ctx.executable.runner,
-        arguments = args,
-        progress_message = "Running PostCSS runner on %s" % ctx.attr.src.label,
-    )
+    _run_one(ctx, input_css, input_map, ctx.outputs.css_file, ctx.outputs.css_map_file)
 
 def _postcss_run_outputs(output_name):
     output_name = output_name or "%{name}.css"
@@ -89,4 +96,58 @@ postcss_run = rule(
         ),
     },
     outputs = _postcss_run_outputs,
+)
+
+def _postcss_multi_run_impl(ctx):
+    # A dict from .css filenames to two-element lists which contain
+    # [CSS file, soucemap file]. It's an error for a sourcemap to exist
+    # without a CSS file, but not vice versa.
+    files_by_name = {}
+    for f in ctx.files.srcs:
+        if f.extension == "map":
+            files_by_name.setdefault(_strip_extension(f.path), [None, None])[1] = f
+        else:
+            files_by_name.setdefault(f.path, [None, None])[0] = f
+
+    outputs = []
+    for (input_css, input_map) in files_by_name.values():
+        if not input_css:
+            fail("Source map file %s was passed without a corresponding CSS file." % input_map.path)
+
+        output_name = ctx.attr.output_pattern.format(
+            name = input_css.basename,
+            dir = input_css.dirname,
+            rule = ctx.label.name
+        )
+
+        output_css = ctx.actions.declare_file(output_name)
+        output_map = ctx.actions.declare_file(output_name + ".map")
+        outputs.append(output_css)
+        outputs.append(output_map)
+
+        _run_one(ctx, input_css, input_map, output_css, output_map)
+
+    return DefaultInfo(files = depset(outputs))
+
+def _strip_extension(path):
+    """Removes the final extension from a path."""
+    components = path.split(".")
+    components.pop()
+    return ".".join(components)
+
+postcss_multi_run = rule(
+    implementation = _postcss_multi_run_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".css", ".css.map"],
+            mandatory = True,
+        ),
+        "output_pattern": attr.string(default = "{rule}/{name}"),
+        "runner": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test", "rule_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -81,4 +81,15 @@ file_test(
     name = "additional_outputs_test",
     content = ADDITIONAL_OUTPUT,
     file = "//examples/additional_outputs:selectors.md",
+)
+
+rule_test(
+    name = "multi_binary_test",
+    rule = "//examples/multi_binary:styles",
+    generates = [
+        "styles/examples/multi_binary/style1.css",
+        "styles/examples/multi_binary/style1.css.map",
+        "styles/examples/multi_binary/style2.css",
+        "styles/examples/multi_binary/style2.css.map",
+    ]
 )


### PR DESCRIPTION
This is useful when compiling CSS from files that aren't known at
load-time, such as from transitive deps.