### PR TITLE
Make postcss_multi_binary Python-compatible

### DIFF
--- a/internal/multi_binary.bzl
+++ b/internal/multi_binary.bzl
@@ -69,7 +69,7 @@ def postcss_multi_binary(
     postcss_gen_runner(
         name = runner_name,
         plugins = plugins,
-        deps = deps + plugins.keys(),
+        deps = deps + list(plugins.keys()),
         sourcemap = sourcemap,
         **dicts.add(kwargs, {"visibility": ["//visibility:private"]})
     )


### PR DESCRIPTION
Within Google, `.bzl` files are occasionally interpreted as Python. In
Python, you can't directly concatenate a list with a dictionary's keys.