### PR TITLE
Refactor PostCSS plugin require() calls to the runner JS

### DIFF
--- a/internal/gen_runner.bzl
+++ b/internal/gen_runner.bzl
@@ -30,15 +30,15 @@ def _postcss_runner_src_impl(ctx):
     plugins = []
     for plugin_key, plugin_options in ctx.attr.plugins.items():
         node_require = plugin_key[PostcssPluginInfo].node_require
-        plugins.append("require('%s').apply(this, %s)" %
+        plugins.append("'%s': %s" %
                        (node_require, plugin_options if plugin_options else "[]"))
 
     ctx.actions.expand_template(
         template = ctx.file.template,
         output = ctx.outputs.postcss_runner_src,
         substitutions = {
-            # The array of PostCSS plugin objects.
-            "TEMPLATED_plugins": "[%s]" % (",".join(plugins)) if plugins else "",
+            # Map of PostCSS plugin requires => arrays of args to the plugins.
+            "TEMPLATED_plugins": "{%s}" % (",".join(plugins)) if plugins else "",
             # Lowercase Python boolean converts to true/false.
             "TEMPLATED_sourcemap": str(ctx.attr.sourcemap).lower(),
         },

--- a/internal/runner-template.js
+++ b/internal/runner-template.js
@@ -80,7 +80,13 @@ const outCssPath = path.join(cwd, args.outCssFile);
 const outCssMapPath =
     args.outCssMapFile ? path.join(cwd, args.outCssMapFile) : null;
 
-postcss(TEMPLATED_plugins)
+// We receive a map of PostCSS plugin requires => array of args to the plugins.
+// To use in PostCSS, convert this map into the actual plugin instances.
+const pluginMap = TEMPLATED_plugins;
+const pluginInstances = Object.entries(pluginMap).map(
+    ([nodeRequire, args]) => require(nodeRequire).apply(this, args));
+
+postcss(pluginInstances)
     .process(cssString, options)
     .then(
         result => {


### PR DESCRIPTION
Instead of generating the require() calls as a string in Starlark.

This minor refactor slightly reduces the templated JS, and clarifies how we get the plugins from Starlark into the runner.

A followup to this PR can be to log a useful warning message if the Node.js require failed.