### PR TITLE
Shorten unnecessary longhand label references

### DIFF
--- a/internal/autoprefixer/build_defs.bzl
+++ b/internal/autoprefixer/build_defs.bzl
@@ -38,7 +38,7 @@ def autoprefixer(
     postcss_binary(
         name = name,
         plugins = {
-            "@build_bazel_rules_postcss//internal/autoprefixer:autoprefixer": "[{ browsers: '%s' }]" % (browsers),
+            "@build_bazel_rules_postcss//internal/autoprefixer": "[{ browsers: '%s' }]" % (browsers),
         },
         src = src,
         output_name = out,

--- a/internal/rtlcss/build_defs.bzl
+++ b/internal/rtlcss/build_defs.bzl
@@ -33,7 +33,7 @@ def rtlcss(
     postcss_binary(
         name = name,
         plugins = {
-            "@build_bazel_rules_postcss//internal/rtlcss:rtlcss": "",
+            "@build_bazel_rules_postcss//internal/rtlcss": "",
         },
         src = src,
         output_name = out,


### PR DESCRIPTION
It seems the shorthand `//foo/plugin` can be used to refer to `//foo/plugin:plugin` between when #23 was filed and now; shorthand labels are an expected convention so let's use shorthand labels where possible.

Closes #23