### PR TITLE
Rudimentary worker support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,7 @@
 ---
 buildifier:
   version: latest
-platforms:
+tasks:
   ubuntu1604:
     build_targets:
     - "..."
@@ -17,3 +17,33 @@ platforms:
     - "..."
     test_targets:
     - "..."
+  ubuntu1604_worker:
+    platform: ubuntu1604
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+    build_flags:
+    - "--strategy=PostCSSRunner=worker"
+    test_flags:
+    - "--strategy=PostCSSRunner=worker"
+  ubuntu1804_worker:
+    platform: ubuntu1804
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+    build_flags:
+    - "--strategy=PostCSSRunner=worker"
+    test_flags:
+    - "--strategy=PostCSSRunner=worker"
+  macos_worker:
+    platform: macos
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+    build_flags:
+    - "--strategy=PostCSSRunner=worker"
+    test_flags:
+    - "--strategy=PostCSSRunner=worker"

--- a/internal/binary.bzl
+++ b/internal/binary.bzl
@@ -79,7 +79,8 @@ def postcss_binary(
             accessed through `bazel.data.${name}`.
         wrapper: Wrapper for the postcss binary. If passed, the wrapper is run
             in place of the postcss binary, with an extra first arg pointing
-            to the actual postcss binary.
+            to the actual postcss binary. (Workers are not supported when using
+            a wrapper.)
         **kwargs: Standard BUILD arguments to pass.
     """
 

--- a/internal/run.bzl
+++ b/internal/run.bzl
@@ -101,6 +101,8 @@ def _run_one(ctx, input_css, input_map, output_css, output_map):
             tools = [],
             arguments = [args],
             progress_message = "Running PostCSS runner on %s" % input_css,
+            execution_requirements = { "supports-workers": "1" },
+            mnemonic = "PostCSSRunner",
         )
 
     return outputs

--- a/internal/run.bzl
+++ b/internal/run.bzl
@@ -80,6 +80,7 @@ def _run_one(ctx, input_css, input_map, output_css, output_map):
     # If a wrapper binary is passed, run it. It gets the actual binary as an
     # input and the path to it as the first arg.
     if ctx.executable.wrapper:
+        # If using a wrapper, running as a worker is currently unsupported.
         ctx.actions.run(
             inputs = inputs,
             outputs = outputs,
@@ -89,8 +90,6 @@ def _run_one(ctx, input_css, input_map, output_css, output_map):
             progress_message = "Running PostCSS wrapper on %s" % input_css,
         )
     else:
-        # flagfile is easy to do directly, need to figure out how to do this
-        # cleanly for wrappers though
         args.use_param_file("@%s", use_always = True)
         args.set_param_file_format("multiline")
         run_node(

--- a/internal/run.bzl
+++ b/internal/run.bzl
@@ -89,6 +89,10 @@ def _run_one(ctx, input_css, input_map, output_css, output_map):
             progress_message = "Running PostCSS wrapper on %s" % input_css,
         )
     else:
+        # flagfile is easy to do directly, need to figure out how to do this
+        # cleanly for wrappers though
+        args.use_param_file("@%s", use_always = True)
+        args.set_param_file_format("multiline")
         run_node(
             ctx = ctx,
             inputs = inputs,

--- a/internal/runner.js
+++ b/internal/runner.js
@@ -90,24 +90,24 @@ function compile(rawArgs) {
   const pluginInstances = pluginRequires.map(
       (nodeRequire, i) => {
         // Try and resolve this plugin as a module identifier.
-        let plugin;	
-        try {	
-          plugin = require(nodeRequire);	
-        } catch { }	
+        let plugin;
+        try {
+          plugin = require(nodeRequire);
+        } catch { }
 
-        // If it fails, use the runfile helper in case it's a workspace file.	
-        if (!plugin) {	
-          try {	
-            plugin = require(runfiles.resolve(nodeRequire));	
-          } catch { }	
-        }	
+        // If it fails, use the runfile helper in case it's a workspace file.
+        if (!plugin) {
+          try {
+            plugin = require(runfiles.resolve(nodeRequire));
+          } catch { }
+        }
 
-        // If that still fails, throw an error.	
-        if (!plugin) {	
-          const e = new Error(	
-              `could not resolve plugin with node require ${nodeRequire}`);	
-          e.code = 'MODULE_NOT_FOUND';	
-          throw e;	
+        // If that still fails, throw an error.
+        if (!plugin) {
+          const e = new Error(
+              `could not resolve plugin with node require ${nodeRequire}`);
+          e.code = 'MODULE_NOT_FOUND';
+          throw e;
         }
 
         return plugin.apply(this, eval(pluginArgs[i]));

--- a/internal/runner.js
+++ b/internal/runner.js
@@ -25,6 +25,7 @@ const minimist = require('minimist');
 const path = require('path');
 const postcss = require('postcss');
 const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const worker = require('@bazel/worker');
 
 /**
  * Returns the argument named `name` as an array.

--- a/internal/runner.js
+++ b/internal/runner.js
@@ -50,9 +50,9 @@ function compile(rawArgs) {
     const [name, value] = pair.split(':');
     (data[name] = data[name] || []).push(value);
   }
-
-  // These variables are documented in `postcss_binary`'s docstring and are fair
-  // game for plugin configuration to read.
+  
+  // These variables are documented in `postcss_binary`'s docstring and are
+  // fair game for plugin configuration to read.
   const bazel = {
     binDir: args.binDir,
     data: data,
@@ -68,11 +68,11 @@ function compile(rawArgs) {
     to: args.outCssFile,
     map: args.sourcemap
         ? {
-            // Don't output the source map inline, we want it as a separate file.
+            // Don't output source map inline, we want it as a separate file.
             inline: false,
             // Whether to add (or modify, if already existing) the
-            // sourceMappingURL comment in the output .css to point to the output
-            // .css.map.
+            // sourceMappingURL comment in the output .css to point to the
+            // output .css.map.
             annotation: true,
           }
         : false,
@@ -82,8 +82,8 @@ function compile(rawArgs) {
   const outCssPath = path.join(cwd, args.outCssFile);
   const outCssMapPath =
       args.outCssMapFile ? path.join(cwd, args.outCssMapFile) : null;
-
-  // We use two parallel arrays of PostCSS plugin requires => strings of JS args.
+  
+  // We use two parallel arrays, PostCSS plugin requires => strings of JS args.
   // To use in PostCSS, convert these into the actual plugin instances.
   const pluginRequires = argAsArray(args, 'pluginRequires');
   const pluginArgs = argAsArray(args, 'pluginArgs');

--- a/internal/runner.js
+++ b/internal/runner.js
@@ -27,44 +27,6 @@ const postcss = require('postcss');
 const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 const worker = require('@bazel/worker');
 
-const pluginCache = new Map();
-
-/**
- * Returns a plugin from its module identifier or Bazel workspace path.
- * 
- * If not yet required, requires and caches it for fast return later.
- */
-function requirePlugin(nodeRequire) {
-  // Return early if in cache.
-  if (pluginCache.has(nodeRequire)) {
-    return pluginCache.get(nodeRequire);
-  }
-
-  // Try and resolve this plugin as a module identifier.
-  let plugin;
-  try {
-    plugin = require(nodeRequire);
-  } catch { }
-
-  // If it fails, use the runfile helper in case it's a workspace file.
-  if (!plugin) {
-    try {
-      plugin = require(runfiles.resolve(nodeRequire));
-    } catch { }
-  }
-
-  // If that still fails, throw an error.
-  if (!plugin) {
-    const e = new Error(
-        `could not resolve plugin with node require ${nodeRequire}`);
-    e.code = 'MODULE_NOT_FOUND';
-    throw e;
-  }
-
-  pluginCache.set(nodeRequire, plugin);
-  return plugin;
-}
-
 /**
  * Returns the argument named `name` as an array.
  *
@@ -127,7 +89,27 @@ function compile(rawArgs) {
   const pluginArgs = argAsArray(args, 'pluginArgs');
   const pluginInstances = pluginRequires.map(
       (nodeRequire, i) => {
-        const plugin = requirePlugin(nodeRequire);
+        // Try and resolve this plugin as a module identifier.
+        let plugin;	
+        try {	
+          plugin = require(nodeRequire);	
+        } catch { }	
+
+        // If it fails, use the runfile helper in case it's a workspace file.	
+        if (!plugin) {	
+          try {	
+            plugin = require(runfiles.resolve(nodeRequire));	
+          } catch { }	
+        }	
+
+        // If that still fails, throw an error.	
+        if (!plugin) {	
+          const e = new Error(	
+              `could not resolve plugin with node require ${nodeRequire}`);	
+          e.code = 'MODULE_NOT_FOUND';	
+          throw e;	
+        }
+
         return plugin.apply(this, eval(pluginArgs[i]));
       });
 

--- a/internal/runner.js
+++ b/internal/runner.js
@@ -50,7 +50,7 @@ function compile(rawArgs) {
     const [name, value] = pair.split(':');
     (data[name] = data[name] || []).push(value);
   }
-  
+
   // These variables are documented in `postcss_binary`'s docstring and are
   // fair game for plugin configuration to read.
   const bazel = {
@@ -82,7 +82,7 @@ function compile(rawArgs) {
   const outCssPath = path.join(cwd, args.outCssFile);
   const outCssMapPath =
       args.outCssMapFile ? path.join(cwd, args.outCssMapFile) : null;
-  
+
   // We use two parallel arrays, PostCSS plugin requires => strings of JS args.
   // To use in PostCSS, convert these into the actual plugin instances.
   const pluginRequires = argAsArray(args, 'pluginRequires');
@@ -112,7 +112,7 @@ function compile(rawArgs) {
 
         return plugin.apply(this, eval(pluginArgs[i]));
       });
-  
+
   return postcss(pluginInstances)
       .process(cssString, options)
       .then(

--- a/internal/runner_bin.bzl
+++ b/internal/runner_bin.bzl
@@ -37,6 +37,7 @@ def postcss_runner_bin(
         data = [
             "@npm//minimist",
             "@npm//postcss",
+            "@npm//@bazel/worker",
         ] + deps,
         **kwargs
     )

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "postcss": "^7.0.7"
     },
     "devDependencies": {
-        "@bazel/typescript": "^2.0.0"
+        "@bazel/typescript": "^2.0.0",
+        "@bazel/worker": "^2.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@
     source-map-support "0.5.9"
     tsutils "2.27.2"
 
+"@bazel/worker@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-2.0.0.tgz#904de1708198b68cf90f088b43d1a7eb0a9cc252"
+  integrity sha512-YKlEbKOZ51QIngN5FKZAsT9xRoZfeQGsb1ZDUqn8G7GnfzMuqlqzKEXFU8D3RwEO5rwJ8d7zhYqEKBjA9XfA8Q==
+  dependencies:
+    protobufjs "6.8.8"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"


### PR DESCRIPTION
This implementation uses the `@bazel/worker` npm package to support workers. (A followup PR could inline this dep depending on how complex it is.)

`bazel test //tests/... --strategy=PostCSSRunner=worker` can trigger the worker.

#58 is used as a base to make this PR diff easier to understand.

This PR starts work on #45.