### PR TITLE
Build runner flags with Args instead of a list

### DIFF
--- a/examples/wrapper/wrapper.sh
+++ b/examples/wrapper/wrapper.sh
@@ -29,7 +29,9 @@ $executable $@
 echo "finished running wrapped executable"
 
 while [ $# -gt 0 ]; do
-    if case $1 in "--outCssFile="*) true;; *) false;; esac; then
+    if case $1 in "--outCssFile"*) true;; *) false;; esac; then
+        # Take the argv after the flag --outCssFile
+        shift
         outCssFile=$(printf '%s' "$1" | sed 's/--outCssFile=//')
     fi
     shift

--- a/internal/run.bzl
+++ b/internal/run.bzl
@@ -43,7 +43,7 @@ def _run_one(ctx, input_css, input_map, output_css, output_map):
 
     data = [t.files for t in ctx.attr.data] + [t.files for t in ctx.attr.named_data.keys()]
     for files in data:
-        args.add_all("--data", files.to_list())
+        args.add_all("--data", files)
 
     for (target, name) in ctx.attr.named_data.items():
         for file in target.files.to_list():


### PR DESCRIPTION
(Note: Args can only be appended to, not prepended. It also generates output in the form of `--foo bar`, not `--foo=bar`.)