### PR TITLE
Add stardoc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 # BEGIN-INTERNAL
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 # END-INTERNAL
 
 bzl_library(
@@ -30,6 +31,14 @@ bzl_library(
 exports_files(["LICENSE"])
 
 # BEGIN-INTERNAL
+stardoc(
+    name = "docs",
+    input = "index.bzl",
+    out = "doc.md",
+    deps = ["//:build_defs"],
+    symbol_names = ["postcss_binary", "postcss_multi_binary", "postcss_plugin"],
+)
+
 exports_files(
     ["tsconfig.json"],
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,10 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/internal/BUILD
+++ b/internal/BUILD
@@ -23,6 +23,11 @@ filegroup(
 bzl_library(
     name = "build_defs",
     srcs = glob(["*.bzl"]),
+    deps = [
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:paths",
+        "@build_bazel_rules_nodejs//:bzl",
+    ],
     visibility = ["//:__subpackages__"],
 )
 

--- a/package.bzl
+++ b/package.bzl
@@ -44,7 +44,9 @@ def rules_postcss_dependencies():
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
-        # Un-dummy-ify skylib loading so we can dep on bzl_library targets.
+        # Un-dummy-ify skylib loading so that we can dep on bzl_library targets
+        # from rules_nodejs (i.e. those for nodejs_binary). Having correct deps
+        # in bzl_library is required for skydoc to function.
         patches = ["@build_bazel_rules_postcss//:rules_nodejs_skylib.patch"],
         sha256 = "5bf77cc2d13ddf9124f4c1453dd96063774d755d4fc75d922471540d1c9a8ea8",
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.0/rules_nodejs-2.0.0.tar.gz"],

--- a/package.bzl
+++ b/package.bzl
@@ -14,6 +14,7 @@
 
 """Fetches transitive dependencies required for using the PostCSS rules"""
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _include_if_not_defined(repo_rule, name, **kwargs):
@@ -32,10 +33,19 @@ def rules_postcss_dependencies():
         sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
     )
 
+    _include_if_not_defined(
+        git_repository,
+        name = "io_bazel_stardoc",
+        remote = "https://github.com/bazelbuild/stardoc.git",
+        commit = "247c2097e7346778ac8d03de5a4770d6b9890dc5",
+    )
+
     # NodeJS rules.
     _include_if_not_defined(
         http_archive,
         name = "build_bazel_rules_nodejs",
+        # Un-dummy-ify skylib loading so we can dep on bzl_library targets.
+        patches = ["@build_bazel_rules_postcss//:rules_nodejs_skylib.patch"],
         sha256 = "5bf77cc2d13ddf9124f4c1453dd96063774d755d4fc75d922471540d1c9a8ea8",
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.0/rules_nodejs-2.0.0.tar.gz"],
     )

--- a/rules_nodejs_skylib.patch
+++ b/rules_nodejs_skylib.patch
@@ -1,0 +1,191 @@
+diff --git BUILD.bazel BUILD.bazel
+index efda7cf..3a51205 100755
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -12,9 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load("@build_bazel_rules_nodejs//:index.bzl", "COMMON_REPLACEMENTS", "pkg_npm")
+ # defaults.bzl not included in distribution
+ # load("//:tools/defaults.bzl", "codeowners", "pkg_tar")
+@@ -43,6 +41,7 @@ bzl_library(
+         "//internal/common:bzl",
+         "//internal/generated_file_test:bzl",
+         "//internal/linker:bzl",
++        "//internal/node:bzl",
+         "//internal/pkg_npm:bzl",
+         "//internal/pkg_web:bzl",
+         "//internal/providers:bzl",
+diff --git internal/bazel_integration_test/BUILD.bazel internal/bazel_integration_test/BUILD.bazel
+index eab3886..bbc085e 100755
+--- internal/bazel_integration_test/BUILD.bazel
++++ internal/bazel_integration_test/BUILD.bazel
+@@ -12,9 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+ 
+ package(default_visibility = ["//visibility:public"])
+diff --git internal/common/BUILD.bazel internal/common/BUILD.bazel
+index f0412d4..da34750 100755
+--- internal/common/BUILD.bazel
++++ internal/common/BUILD.bazel
+@@ -12,9 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load(":check_version_test.bzl", "check_version_test_suite")
+ 
+ licenses(["notice"])  # Apache 2.0
+diff --git internal/generated_file_test/BUILD internal/generated_file_test/BUILD
+index 3e753a7..2d4b2ef 100755
+--- internal/generated_file_test/BUILD
++++ internal/generated_file_test/BUILD
+@@ -1 +1,9 @@
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
++
++bzl_library(
++    name = "bzl",
++    srcs = glob(["*.bzl"]),
++    visibility = ["//visibility:public"],
++)
++
+ exports_files(["bundle.js"])
+\ No newline at end of file
+diff --git internal/js_library/BUILD.bazel internal/js_library/BUILD.bazel
+index 054a5f3..6f29827 100755
+--- internal/js_library/BUILD.bazel
++++ internal/js_library/BUILD.bazel
+@@ -1,6 +1,4 @@
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ 
+ bzl_library(
+     name = "bzl",
+diff --git internal/linker/BUILD.bazel internal/linker/BUILD.bazel
+index 40140a2..7531995 100755
+--- internal/linker/BUILD.bazel
++++ internal/linker/BUILD.bazel
+@@ -1,4 +1,12 @@
+ 
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
++
++bzl_library(
++    name = "bzl",
++    srcs = glob(["*.bzl"]),
++    visibility = ["//visibility:public"],
++)
++
+ exports_files([
+     "index.js",
+     "runfiles_helper.js",
+diff --git internal/node/BUILD.bazel internal/node/BUILD.bazel
+index 09cf2b4..f739ff9 100755
+--- internal/node/BUILD.bazel
++++ internal/node/BUILD.bazel
+@@ -12,9 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+ 
+ package(default_visibility = ["//visibility:public"])
+diff --git internal/npm_install/BUILD.bazel internal/npm_install/BUILD.bazel
+index 6fd3f08..d2b7b8f 100755
+--- internal/npm_install/BUILD.bazel
++++ internal/npm_install/BUILD.bazel
+@@ -1,6 +1,4 @@
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+ 
+ 
+diff --git internal/pkg_npm/BUILD.bazel internal/pkg_npm/BUILD.bazel
+index 486ea55..ea0addb 100755
+--- internal/pkg_npm/BUILD.bazel
++++ internal/pkg_npm/BUILD.bazel
+@@ -1,6 +1,4 @@
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+ 
+ package(default_visibility = ["//visibility:public"])
+diff --git internal/pkg_web/BUILD.bazel internal/pkg_web/BUILD.bazel
+index 6bb3fa7..3f0bf48 100755
+--- internal/pkg_web/BUILD.bazel
++++ internal/pkg_web/BUILD.bazel
+@@ -1,6 +1,4 @@
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+ 
+ 
+diff --git internal/providers/BUILD.bazel internal/providers/BUILD.bazel
+index ace773c..7125f08 100755
+--- internal/providers/BUILD.bazel
++++ internal/providers/BUILD.bazel
+@@ -12,9 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ 
+ bzl_library(
+     name = "bzl",
+diff --git third_party/github.com/bazelbuild/bazel-skylib/BUILD third_party/github.com/bazelbuild/bazel-skylib/BUILD
+index 10db32d..16b5313 100755
+--- third_party/github.com/bazelbuild/bazel-skylib/BUILD
++++ third_party/github.com/bazelbuild/bazel-skylib/BUILD
+@@ -1,6 +1,4 @@
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ 
+ licenses(["notice"])
+ 
+diff --git toolchains/node/BUILD.bazel toolchains/node/BUILD.bazel
+index 02a0559..0bd7022 100755
+--- toolchains/node/BUILD.bazel
++++ toolchains/node/BUILD.bazel
+@@ -11,9 +11,7 @@
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-# bazel_skylib mocked out
+-# load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", bzl_library = "dummy_bzl_library")
++load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+ 
+ package(default_visibility = ["//visibility:private"])
+ 
+-- 


### PR DESCRIPTION
stardoc relies on feeding in a bzl or bzl_library that cover the rules to be documented.

Because the rules in this case depend on skylib and rules_nodejs, they should be added as deps to their associated bzl_library. They previously were not.

However, rules_nodejs is distributed with bzl_library references replaced with dummy references. A patch is needed to reverse this change to make the bzl_library dep work, and in turn allow stardoc to work as expected.

stardoc's output markdown can then be include()d into a docsite. Example output: 
[docs.pdf](https://github.com/bazelbuild/rules_postcss/files/5364851/docs.pdf) (pdf exported from Xcode from md), 
[doc.md.zip](https://github.com/bazelbuild/rules_postcss/files/5364856/doc.md.zip) (zip of md)

Fixes #34