### PR TITLE
Add `rules_postcss_dependencies()` info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ See https://github.com/bazelbuild/rules_nodejs/#quickstart
 This causes the build rules to be made available under
 `@npm//@bazel/postcss:index.bzl`.
 
+Lastly, in your `WORKSPACE` file, add `rules_postcss` dependencies:
+
+```python
+load("@npm//@bazel/postcss:package.bzl", "rules_postcss_dependencies")
+rules_postcss_dependencies()
+```
+
 **TODO:** Compare to using PostCSS directly using `rules_nodejs`.
 
 ### Using repository rules
@@ -58,6 +65,8 @@ http_archive(
     strip_prefix = "rules_postcss-0.5.0",
     sha256 = "3f0c754f97e3940ea90f4d6408bfb2aefb3850e7941572b22b1b88579c428ff9",
 )
+load("@build_bazel_rules_postcss//:package.bzl", "rules_postcss_dependencies")
+rules_postcss_dependencies()
 ```
 
 This causes the build rules to be made available under


### PR DESCRIPTION
While trying to use `rules_postcss` I found that I needed to call `rules_postcss_dependencies()` to include necessary deps like Skylib. This appears to be undocumented in the repository, despite being necessary. Let me know if I'm misunderstanding how this function is supposed to be used.