### PR TITLE
Improve error formatting

### DIFF
--- a/internal/runner.js
+++ b/internal/runner.js
@@ -124,9 +124,15 @@ function compile(rawArgs) {
             return true;
           },
           e => {
-            worker.log('Error in processing. Args:', args);
-            worker.log('Error:', e);
-            return false;
+            // cssnano (and possibly other packages) can emit errors that aren't
+            // instances of PostCSS's CssSyntaxError class, but that have a
+            // postcssNode field which allows us to construct our own
+            // CssSyntaxError. We do so because its error formatting is more
+            // thorough.
+            if (e.postcssNode) e = e.postcssNode.error(e.message);
+
+            console.warn(e.toString());
+            process.exit(2);
           });
 }
 

--- a/internal/runner.js
+++ b/internal/runner.js
@@ -132,7 +132,7 @@ function compile(rawArgs) {
             if (e.postcssNode) e = e.postcssNode.error(e.message);
 
             console.warn(e.toString());
-            process.exit(2);
+            return false;
           });
 }
 


### PR DESCRIPTION
The previous error formatting just dumped all the properties of the
error, which was difficult to read. CssSyntaxError.toString() produces
a more nicely-formatted error, with a snippet of the source file
showing where the error occurred.