### PR TITLE
Update runner.js to be compatible with Node14

### DIFF
--- a/internal/runner.js
+++ b/internal/runner.js
@@ -119,7 +119,7 @@ function compile(rawArgs) {
           result => {
             fs.writeFileSync(outCssPath, result.css);
             if (args.sourcemap && result.map) {
-              fs.writeFileSync(outCssMapPath, result.map);
+              fs.writeFileSync(outCssMapPath, result.map.toString());
             }
             return true;
           },


### PR DESCRIPTION
In Node14, `writeFileSync` performs a validation (validateStringAfterArrayBufferView) on the data passed into it and only accepts certain data types (i.e. string, Buffer, TypedArray, or DataView).

Currently `runner.js` passes a SourceMapGenerator into writeFileSync. So it needs to be converted into an accepted type (i.e a string).

This is a change that happened in google internal and should be upstreamed.