### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,6 +7,11 @@ tasks:
     - "//..."
     test_targets:
     - "//..."
+  ubuntu2004:
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
   macos:
     build_targets:
     - "//..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,37 +2,22 @@
 buildifier:
   version: latest
 tasks:
-  ubuntu1604:
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
   ubuntu1804:
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   macos:
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
-  ubuntu1604_worker:
-    platform: ubuntu1604
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
-    build_flags:
-    - "--strategy=PostCSSRunner=worker"
-    test_flags:
-    - "--strategy=PostCSSRunner=worker"
+    - "//..."
   ubuntu1804_worker:
     platform: ubuntu1804
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
     build_flags:
     - "--strategy=PostCSSRunner=worker"
     test_flags:
@@ -40,9 +25,9 @@ tasks:
   macos_worker:
     platform: macos
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
     build_flags:
     - "--strategy=PostCSSRunner=worker"
     test_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,6 +27,16 @@ tasks:
     - "--strategy=PostCSSRunner=worker"
     test_flags:
     - "--strategy=PostCSSRunner=worker"
+  ubuntu2004_worker:
+    platform: ubuntu2004
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+    build_flags:
+    - "--strategy=PostCSSRunner=worker"
+    test_flags:
+    - "--strategy=PostCSSRunner=worker"
   macos_worker:
     platform: macos
     build_targets:


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.