### PR TITLE
Set mnemonic for PostCSS wrapper action.

### DIFF
--- a/internal/run.bzl
+++ b/internal/run.bzl
@@ -88,6 +88,7 @@ def _run_one(ctx, input_css, input_map, output_css, output_map):
             tools = [ctx.executable.runner],
             arguments = [args],
             progress_message = "Running PostCSS wrapper on %s" % input_css.short_path,
+            mnemonic = "PostCSSWrapper",
         )
     else:
         args.use_param_file("@%s", use_always = True)


### PR DESCRIPTION
Inside Google, we're investigating making the mnemonic mandatory to make it easier to track the performance of a particular action across builds.